### PR TITLE
added OUTLOOK to Mail & added Vivaldi browser mapping

### DIFF
--- a/src/lib/icon_loader.ts
+++ b/src/lib/icon_loader.ts
@@ -30,7 +30,7 @@ iconMap.push({
   icon: BrandChrome
 });
 
-import BrandVivaldi from "@tabler/icons-svelte/icons/brand-vivaldi;
+import BrandVivaldi from "@tabler/icons-svelte/icons/brand-vivaldi";
 iconMap.push({ appNames: ["vivaldi"], icon: BrandVivaldi });
 
 import BrandFirefox from "@tabler/icons-svelte/icons/brand-firefox";


### PR DESCRIPTION
I have adjusted the mapping for Outlook. “olk” didn't work for me with glazewm at the time, so I had to use “OUTLOOK” as the process name for window routing. Hope it works here too :-)

I have also added a mapping for the Vivaldi browser.

Btw: It's my first pull request, hope everything is correct. :-) 